### PR TITLE
docker-user: Add WORKDIR set to $HOME

### DIFF
--- a/docker-user/Dockerfile
+++ b/docker-user/Dockerfile
@@ -6,4 +6,6 @@ RUN adduser -D -u 2000 -G testgroup testuser
 
 USER testuser
 
+WORKDIR /home/testuser
+
 CMD id

--- a/docker-user/README.md
+++ b/docker-user/README.md
@@ -5,3 +5,6 @@ config USER.
 
 When the container is run, using `--oci` mode, the container id output
 should reflect the USER entry in the Dockerfile.
+
+The WORKDIR of the container is set to the user's home directory
+(`/home/testuser`).


### PR DESCRIPTION
WORKDIR is often set to a USER home directory, for example when a conda environment is installed for a non-root user in a container.

It makes sense to set WORKDIR here with USER so that they can be tested together.